### PR TITLE
Change URL to improve git protocol security

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "ext/peg-parser"]
 	path = ext/peg-parser
-	url = git://github.com/dylan-lang/peg-parser.git
+	url = https://github.com/dylan-lang/peg-parser.git
 [submodule "ext/slot-visitor"]
 	path = ext/slot-visitor
-	url = git://github.com/dylan-lang/slot-visitor.git
+	url = https://github.com/dylan-lang/slot-visitor.git
 [submodule "ext/sequence-stream"]
 	path = ext/sequence-stream
-	url = git://github.com/dylan-lang/sequence-stream.git
+	url = https://github.com/dylan-lang/sequence-stream.git


### PR DESCRIPTION
As a result of GitHub's most recent Improving Git protocol security,
which was released on January 11, 2022, Final brownout.